### PR TITLE
Release v0.1.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azamcodec"
-version = "0.1.6"
+version = "0.1.5"
 edition = "2021"
 authors = [ "Azamshul Azizy <azamshul@gmail.com>" ]
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [ "Azamshul Azizy <azamshul@gmail.com>" ]
 license = "MIT"
 repository = "https://github.com/azam/azamcodec-rs"
 description = "Encoder and decoder library for Azam Codec"
-categories = ["encoding", "decoding", "data-structures"]
+categories = ["encoding", "data-structures"]
 keywords = [ "azam", "identifier", "sortable" ]
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "azamcodec"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = [ "Azamshul Azizy <azamshul@gmail.com>" ]
 license = "MIT"


### PR DESCRIPTION
* Remove unsupported category
* Update uuid for benchmark
* Update Github actions
* Preallocate vec for decode based on target platform bitness. Minor matching change.
* Fix clippy warnings. Add odd length id benchmarks. Update criterion.